### PR TITLE
Move config file to standard location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# 0.2.0
+
+Changed location of config file
+
+now following the OS standard
+
+    // Linux:   /home/alice/.config/pndev/pndev.toml
+    // macOS:   /Users/Alice/Library/Preferences/rs.pndev.pndev/pndev.toml
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,7 +1007,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "pndev"
-version = "0.1.21"
+version = "0.2.0"
 dependencies = [
  "ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap-log-flag 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pndev"
-version = "0.1.21"
+version = "0.2.0"
 authors = ["Mattia Gheda <ghedamat@gmail.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -13,18 +13,28 @@ from the [releases](https://github.com/PrecisionNutrition/pndev/releases) page.
 
 ## Configure
 
-If you would like to customize the installation path for the repositories you can create a
-`.pndev_config.toml` file in your home directory;
+To customize the cloning path for the PN repositories you edit or create modify the `pndev` config file.
+
+The location of this file depends on your operating system.
+
+    // Linux:   /home/alice/.config/pndev/pndev.toml
+    // macOS:   /Users/Alice/Library/Preferences/rs.pndev.pndev/pndev.toml
+
+if this is your first time using `pndev` you can run `pndev doctor` and the config file will be generated
 
 ```
 # run
 pndev doctor
-# this will create a ~/.pndev_config.toml for you to edit if you don't have one
+
+# edit the generated config file
+# Linux:   /home/alice/.config/pndev/pndev.toml
+# macOS:   /Users/Alice/Library/Preferences/rs.pndev.pndev/pndev.toml
 ```
 
 ### Config file format
 
 ```
+# install path is relative to your home directory, do not use trailing slashes
 install_path = 'DEV/PN'
 ```
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,13 +17,14 @@ impl ::std::default::Default for Config {
     }
 }
 
-const CONFIG_FILE_NAME: &str = ".pndev_config";
+// Linux:   /home/alice/.config/pndev/pndev.toml
+// macOS:   /Users/Alice/Library/Preferences/rs.pndev.pndev/pndev.toml
+const CONFIG_FILE_NAME: &str = "pndev";
 
 impl Config {
     pub fn new() -> Self {
-        let path = format!("{}/{}", Self::home_path_str(), CONFIG_FILE_NAME);
-        info!("Loading config from {}.toml", path);
-        let cfg: Config = confy::load(&path).expect("Config load/write failed");
+        info!("Loading/generating config file");
+        let cfg: Config = confy::load(CONFIG_FILE_NAME).expect("Config load/write failed");
         cfg
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,8 @@ fn main() -> Result<(), ExitFailure> {
     warn!("LogLevel Warn");
     info!("LogLevel Info");
 
+    config::Config::new();
+
     let command_result = match args.command {
         CliCommand::Prepare => Command::prepare(),
         CliCommand::Shell => Command::shell(),


### PR DESCRIPTION
the `comfy` crate uses the `directories` crate to automatically
position the config file in the standard place

https://docs.rs/directories/2.0.2/directories/struct.ProjectDirs.html

this IS a breaking change but allows us to reduce code and follow
conventions

/cc @typeoneerror 

closes #9 and #6 