### PR TITLE
Increase `shm_size` to 512mb

### DIFF
--- a/catalog/docker-compose.yml
+++ b/catalog/docker-compose.yml
@@ -70,3 +70,4 @@ services:
       - pgdata11:/var/lib/postgresql/data
     ports:
       - "5432:5432"
+    shm_size: 512mb


### PR DESCRIPTION
I've hit the following error while running postgres locally:
```
PG::DiskFull: ERROR: could not resize shared memory segment "/PostgreSQL.394945862" to 16777216 bytes: No space left on device
```
After some googling I noticed the default shared memory size for postgres is 64MB and I was hitting that limit, I propose we bump it to 512MB instead.

before
```
⇒  docker exec -it 6b5ae5e43bae df -h /dev/shm
Filesystem      Size  Used Avail Use% Mounted on
shm              64M   60M  4.6M  93% /dev/shm
```

after
```
⇒  docker exec -it 66af0df9887d df -h /dev/shm
Filesystem      Size  Used Avail Use% Mounted on
shm             512M  8.0K  512M   1% /dev/shm
```