### PR TITLE
Add a proxy pass directive for nebula so we can avoid CORS issues

### DIFF
--- a/catalog/docker/nginx-minimal.conf
+++ b/catalog/docker/nginx-minimal.conf
@@ -34,6 +34,10 @@ http {
     server dockerhost:8888;
   }
 
+  upstream nebula {
+    server dockerhost:8000;
+  }
+
   include       /etc/nginx/mime.types;
   default_type  application/octet-stream;
 
@@ -71,6 +75,23 @@ http {
       proxy_intercept_errors on;
       add_header             Cache-Control max-age=31536000;
       proxy_pass             $documents;
+    }
+
+    location /nebula {
+      rewrite ^/nebula/?(.*) /$1 break;
+      proxy_pass http://nebula;
+      proxy_pass_request_headers on;
+      proxy_http_version 1.1;
+
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+
+      proxy_buffering off;
+      proxy_read_timeout 86400;
+
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection 'Upgrade';
     }
 
     location /wedge {


### PR DESCRIPTION
@jonhunt-pn we are doing this so that we can make requests to nebula app from space-roost without running into CORS issues. we will need a corresponding PR for the terraform stuff