### PR TITLE
Add pgvector

### DIFF
--- a/catalog/docker/Dockerfile.postgres
+++ b/catalog/docker/Dockerfile.postgres
@@ -2,5 +2,6 @@ FROM postgres:12
 RUN apt-get update \
  && apt-get install --no-install-recommends -y postgresql-12-ip4r \
  && apt-get install --no-install-recommends -y postgresql-12-hll \
+ && apt-get install --no-install-recommends -y postgresql-12-pgvector \
  && rm -rf /var/lib/apt/lists/*
 COPY docker/init-user-db.sh /docker-entrypoint-initdb.d/init-user-db.sh


### PR DESCRIPTION
* @jonhunt-pn as discussed we need to be on pg15 on AWS to install pgvector
* @jonhunt-pn we need to upgrade both the `prod` and `qa` nebula dbs to pg15